### PR TITLE
Interpolate server_url to distribute to subdomains

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    thumbor_rails (0.1.0)
+    thumbor_rails (0.1.1)
       ruby-thumbor (>= 1.2.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ rails g thumbor_rails:install
 ```
 
 It will generate the basic configuration in `config/initializers/thumbor_rails.rb` and you have to update the values of `server_url` to point to your thumbor server and the `security_key` to have your security key.
+If `server_url` contains `%d`, it will be interpolated to 0-3, [just like `asset_host` for Rails](http://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html).
 
 That's all.
 

--- a/lib/thumbor_rails/helpers.rb
+++ b/lib/thumbor_rails/helpers.rb
@@ -8,7 +8,12 @@ module ThumborRails
       options[:image] = image_url
       thumbor_service = crypto_service
       thumbor_service = unsafe_service if options[:unsafe]
-      "#{ThumborRails.server_url}#{thumbor_service.generate(options)}"
+      host = ThumborRails.server_url
+      path = thumbor_service.generate(options)
+      if host =~ /%d/
+        host = host % (Zlib.crc32(path) % 4)
+      end
+      host + path
     end
 
     def thumbor_image_tag(image_url, options = {}, tag_attrs = {})

--- a/lib/thumbor_rails/version.rb
+++ b/lib/thumbor_rails/version.rb
@@ -1,3 +1,3 @@
 module ThumborRails
-  VERSION = '0.1.0'
+  VERSION = '0.1.1'
 end

--- a/spec/thumbor_rails/helpers_spec.rb
+++ b/spec/thumbor_rails/helpers_spec.rb
@@ -15,6 +15,16 @@ describe ThumborRails::Helpers do
     it 'should pass arguments to thumbor' do
       expect(thumbor_url('http://test.img', unsafe: true, width: 100, height: 200)).to eq('http://thumbor.example.com/unsafe/100x200/http://test.img')
     end
+
+    it 'should interpolate thumbor hosts with %d to 0-3, like Rails asset_host' do
+      original_url = ThumborRails.server_url
+      begin
+        ThumborRails.server_url = "http://thumbor%d.com"
+        expect(thumbor_url('http://test.img')).to eq('http://thumbor3.com/yPVDsGJsQKjKky_cdbkNuIpc9-A=/http://test.img')
+      ensure
+        ThumborRails.server_url = original_url
+      end
+    end
   end
 
   describe '#thumbor_image_tag' do


### PR DESCRIPTION
I am setting up Thumbor to sit behind a CDN, which currently responds to `cdn0.server.com`, `cdn1.server.com` (etc) and is configured to play with the Rails `asset_host` distribution. I added this change so that we can use the same `asset_host` we use for the rest of our application and urls will be uniformly, and consistently distributed to different CDN subdomains.
