### PR TITLE
Add 'force_no_protocol_in_source_url' option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    thumbor_rails (0.1.1)
+    thumbor_rails (0.1.2)
       ruby-thumbor (>= 1.2.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ Now generate the thumbor basic client configuration:
 rails g thumbor_rails:install
 ```
 
-It will generate the basic configuration in `config/initializers/thumbor_rails.rb` and you have to update the values of `server_url` to point to your thumbor server and the `security_key` to have your security key.
-If `server_url` contains `%d`, it will be interpolated to 0-3, [just like `asset_host` for Rails](http://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html).
+It will generate the basic configuration in `config/initializers/thumbor_rails.rb`, which has the following configuration options available:
 
-That's all.
+- `server_url`. _Required_. The location of your Thumbor server. If `server_url` contains `%d`, it will be interpolated to 0-3, [just like `asset_host` for Rails](http://api.rubyonrails.org/classes/ActionView/Helpers/AssetUrlHelper.html).
+- `sercurity_key`. Optional. This must match your [Thumbor server's security key](https://github.com/thumbor/thumbor/wiki/Security#stopping-tampering).
+- `force_no_protocol_in_source_url`. Optional, defaults to `false`. If true, the protocol is removed from any image source passed into `thumbor_url`. This may be done for aesthetic reasons, or due to certain CDN/server configurations.
+
 
 ## Usage
 

--- a/lib/thumbor_rails.rb
+++ b/lib/thumbor_rails.rb
@@ -7,6 +7,9 @@ module ThumborRails
   mattr_accessor :security_key
   @@security_key = 'MY_SECURITY_KEY'
 
+  mattr_accessor :force_no_protocol_in_source_url
+  @@force_no_protocol_in_source_url = false
+
   def self.setup
     yield self
   end

--- a/lib/thumbor_rails/helpers.rb
+++ b/lib/thumbor_rails/helpers.rb
@@ -5,6 +5,10 @@ module ThumborRails
     include ActionView::Helpers::AssetTagHelper
 
     def thumbor_url(image_url, options = {})
+      if ThumborRails.force_no_protocol_in_source_url
+        image_url.sub!(/^http(s|):\/\//, '')
+      end
+
       options[:image] = image_url
       thumbor_service = crypto_service
       thumbor_service = unsafe_service if options[:unsafe]

--- a/lib/thumbor_rails/version.rb
+++ b/lib/thumbor_rails/version.rb
@@ -1,3 +1,3 @@
 module ThumborRails
-  VERSION = '0.1.1'
+  VERSION = '0.1.2'
 end

--- a/spec/thumbor_rails/helpers_spec.rb
+++ b/spec/thumbor_rails/helpers_spec.rb
@@ -25,6 +25,17 @@ describe ThumborRails::Helpers do
         ThumborRails.server_url = original_url
       end
     end
+
+    it 'should automatically remove the protocol in source urls if configured to do so' do
+      begin
+        ThumborRails.force_no_protocol_in_source_url = true
+        expect(thumbor_url('http://test.img', unsafe: true)).to eq('http://thumbor.example.com/unsafe/test.img')
+        expect(thumbor_url('https://test.img', unsafe: true)).to eq('http://thumbor.example.com/unsafe/test.img')
+        expect(thumbor_url('www.test.img', unsafe: true)).to eq('http://thumbor.example.com/unsafe/www.test.img')
+      ensure
+        ThumborRails.force_no_protocol_in_source_url = false
+      end
+    end
   end
 
   describe '#thumbor_image_tag' do

--- a/spec/thumbor_rails_spec.rb
+++ b/spec/thumbor_rails_spec.rb
@@ -15,6 +15,10 @@ describe ThumborRails do
     expect(subject).to respond_to 'server_url'
   end
 
+  it 'has force_no_protocol_in_source_url attibute' do
+    expect(subject).to respond_to 'force_no_protocol_in_source_url'
+  end
+
   describe 'when configured' do
     before do
       subject.setup do |config|


### PR DESCRIPTION
Added this option that automatically removes the protocol from source urls. I added this because because the CDN path available to me forces an awkward path and I'm using an nginx rewrite + proxypass configuration to load balance into Thumbor, and nginx collapses `http://` to `http:/`, which causes generation to 404.
