### PR TITLE
Updated version from 0.1.2 to 1.0.1 in VERSION, README.md etc.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    thumbor_rails (0.1.2)
+    thumbor_rails (1.0.1)
       ruby-thumbor (>= 1.2.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ thumbor_rails is a client to make easier to use the thumbor imaging service (htt
 You can use this gem by putting the following inside your Gemfile:
 
 ```
-gem "thumbor_rails", "0.1.2"
+gem "thumbor_rails", "1.0.1"
 ```
 
 Now generate the thumbor basic client configuration:

--- a/lib/thumbor_rails/version.rb
+++ b/lib/thumbor_rails/version.rb
@@ -1,3 +1,3 @@
 module ThumborRails
-  VERSION = '0.1.2'
+  VERSION = '1.0.1'
 end


### PR DESCRIPTION
The recent `1.0.0` tag left these set to `0.1.2`.
I've correct it for the next version in `ThumborRails::VERSION`, and changed the `README.md` to suggest `~> 1.0`.
I also updated `Gemfile.lock`, but I'd suggest that be deleted and added to `.gitignore`.
