### PR TITLE
security_key defaults to nil, not 'MY_SECURITY_KEY'

### DIFF
--- a/lib/thumbor_rails.rb
+++ b/lib/thumbor_rails.rb
@@ -5,7 +5,7 @@ module ThumborRails
   @@server_url = 'http://thumbor.example.com'
 
   mattr_accessor :security_key
-  @@security_key = 'MY_SECURITY_KEY'
+  @@security_key = nil
 
   mattr_accessor :force_no_protocol_in_source_url
   @@force_no_protocol_in_source_url = false


### PR DESCRIPTION
`nil` is a useful value here, as it generates unsigned "unsafe" URLs suitable for hitting thumbor running in unsafe mode - often the case in development environments etc. Defaulting to `nil` means development environments can run thumbor + thumbor_rails without any shared secret.

---

Here's some notes I made in an internal application pull-request leading up to this:

thumbor-rails defaults security key to "MY_SECURITY_KEY":
https://github.com/rafaelcaricio/thumbor_rails/blob/93710ceea2ceace2f19638d8c8481d333126f747/lib/thumbor_rails.rb#L8

It then instantiates Thumbor::CryptoURL with it:
https://github.com/rafaelcaricio/thumbor_rails/blob/93710ceea2ceace2f19638d8c8481d333126f747/lib/thumbor_rails/helpers.rb#L30

CryptoURL wants nil to operate in unsafe mode:
https://github.com/thumbor/ruby-thumbor/blob/65f899df6f33594621e94239dd94806257bcc796/spec/thumbor/crypto_url_spec.rb#L463-L470
