### PR TITLE
Do not modify argument to thumbor_url

### DIFF
--- a/lib/thumbor_rails/helpers.rb
+++ b/lib/thumbor_rails/helpers.rb
@@ -6,7 +6,7 @@ module ThumborRails
 
     def thumbor_url(image_url, options = {})
       if ThumborRails.force_no_protocol_in_source_url
-        image_url.sub!(/^http(s|):\/\//, '')
+        image_url = image_url.sub(/^http(s|):\/\//, '')
       end
 
       options[:image] = image_url


### PR DESCRIPTION
This caused a subtle bug in my application, where my source url was modified in place, stripped of its protocol.
